### PR TITLE
[FEATURE] assign static IPs to machines on the host-only interface

### DIFF
--- a/src/hark/cli/util.py
+++ b/src/hark/cli/util.py
@@ -31,7 +31,7 @@ def promptModelChoice(models):
     while True:
         i = click.prompt('Choose by num', type=int)
         if i > 0 and i <= len(models):
-            return models[i-1]
+            return models[i - 1]
         click.secho('Invalid choice: %d' % i, fg='red')
 
 
@@ -54,7 +54,7 @@ def modelsWithHeaders(models, add_index=False):
         models = [dict(m) for m in models]
         # add num to each of them
         for i, m in enumerate(models):
-            m['num'] = i+1
+            m['num'] = i + 1
 
     # figure out what the field length should be for each field.
     # it is the greatest length of any value for that field in the list of
@@ -108,3 +108,19 @@ def loadLocalContext(hark_home=None, context_class=None):
     if hark_home is not None:
         return context_class(hark_home)
     return context_class.home()
+
+
+def getPrivateInterface(client, machine):
+    ifaces = client.networkInterfaces(machine=machine, kind='private')
+    if not len(ifaces):
+        # TODO(cera) - typed exception
+        raise Exception("No private interface found")
+    return ifaces[0]
+
+
+def printProcedureLines(procedure):
+    for level, msg in procedure.messages():
+        if level == 'error':
+            click.secho(msg, fg='red')
+        else:
+            click.echo(msg)

--- a/src/hark/context/__init__.py
+++ b/src/hark/context/__init__.py
@@ -3,6 +3,7 @@ import os.path
 
 import hark.dal
 import hark.log
+import hark.networking
 
 
 class Context(object):
@@ -19,6 +20,8 @@ class Context(object):
         imagedir = os.path.join(path, 'images')
         self._image_cache = ImageCache(imagedir)
 
+        self._network = hark.networking.Network()
+
     def log_file(self):
         return os.path.join(self.path, 'hark.log')
 
@@ -30,6 +33,9 @@ class Context(object):
 
     def image_cache(self):
         return self._image_cache
+
+    def network(self):
+        return self._network
 
     def _initialize(self, path):
         if not os.path.exists(path):

--- a/src/hark/dal/__init__.py
+++ b/src/hark/dal/__init__.py
@@ -2,8 +2,8 @@ import os
 import sqlite3
 
 from hark.exceptions import (
-        InvalidQueryConstraint,
-        DuplicateModelException
+    InvalidQueryConstraint,
+    DuplicateModelException
 )
 import hark.log
 
@@ -46,6 +46,9 @@ class DAL(object):
                 formatted.append(s)
             elif isinstance(v, str):
                 s = "%s = '%s'" % (k, v)
+                formatted.append(s)
+            elif v is None:
+                s = "%s is null" % k
                 formatted.append(s)
             else:
                 raise InvalidQueryConstraint("Unsupported value: %s" % v)

--- a/src/hark/dal/schema.sql
+++ b/src/hark/dal/schema.sql
@@ -9,8 +9,17 @@ CREATE TABLE machine (
 );
 
 CREATE TABLE port_mapping (
-	host_port INTEGER PRIMARY KEY,
+	host_port  INTEGER PRIMARY KEY,
 	guest_port INTEGER,
 	machine_id char(36),
-	name varchar(255)
+	name       varchar(255)
+);
+
+CREATE TABLE network_interface (
+	machine_id char(36),
+	kind       varchar(255),
+	label      varchar(255),
+	addr       varchar(15),
+
+	PRIMARY KEY (machine_id, kind)
 );

--- a/src/hark/exceptions/__init__.py
+++ b/src/hark/exceptions/__init__.py
@@ -79,3 +79,11 @@ class UnrecognisedMachineState(Exception):
 
 class BadHarkEnvironment(Exception):
     pass
+
+
+class NetworkFull(Exception):
+    def __init__(self, max_avail):
+        msg = 'No available addresses remaining - ' \
+            'the hark network can only support %d hosts; ' \
+            'try removing some hosts first.'
+        Exception.__init__(self, msg)

--- a/src/hark/guest/__init__.py
+++ b/src/hark/guest/__init__.py
@@ -1,23 +1,53 @@
 from hark.exceptions import UnknownGuestException
+from hark.networking import Network
 
 _setupScriptTmpl_Debian = """#!/bin/sh
 set -ex
+
 sudo sh -c "echo '{name}' > /etc/hostname"
 sudo sh -c "echo '{name}' > /etc/mailname"
 sudo hostname -F /etc/hostname
+
+# networking
+cat > /tmp/hark-interfaces-tmp <<EOF
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# The primary network interface
+auto eth0
+iface eth0 inet dhcp
+
+# The private or host-only interface
+auto eth1
+iface eth1 inet static
+    address {private_addr}
+    netmask 255.255.255.0
+EOF
+
+# put the new file in place and restart the network
+sudo mv /tmp/hark-interfaces-tmp /etc/network/interfaces
+sudo /etc/init.d/networking restart
 """
 
 
 class GuestConfig(object):
     def __init__(
-               self,
-               setup_script_template,
-               virtualbox_os_type):
+            self,
+            setup_script_template, virtualbox_os_type):
         self.setup_script_template = setup_script_template
         self._virtualbox_os_type = virtualbox_os_type
 
-    def setup_script(self, machine):
-        return self.setup_script_template.format(**machine)
+    def setup_script(self, machine, private_interface):
+        ntwk = Network()
+        ctx = {}
+        ctx.update(machine)
+        ctx['private_addr'] = private_interface['addr']
+        ctx['host_addr'] = ntwk.get_host_address()
+        return self.setup_script_template.format(**ctx)
 
     def virtualbox_os_type(self):
         return self._virtualbox_os_type

--- a/src/hark/lib/platform.py
+++ b/src/hark/lib/platform.py
@@ -17,7 +17,7 @@ _platformSupport = {
     r'^darwin$': ['virtualbox'],
     r'^linux\d?$': ['qemu', 'virtualbox'],
     r'^win32$': ['virtualbox'],
-    r'^freebsd\d+$':  ['virtualbox'],
+    r'^freebsd\d+$': ['virtualbox'],
 }
 
 

--- a/src/hark/models/image.py
+++ b/src/hark/models/image.py
@@ -5,7 +5,7 @@ import hark.models
 
 
 _file_suffixes = {
-        'virtualbox': 'vmdk',
+    'virtualbox': 'vmdk',
 }
 
 

--- a/src/hark/models/network_interface.py
+++ b/src/hark/models/network_interface.py
@@ -1,0 +1,8 @@
+from hark.models import SQLModel
+
+
+class NetworkInterface(SQLModel):
+    table = 'network_interface'
+    key = ['machine_id', 'kind']
+
+    fields = ['machine_id', 'kind', 'addr']

--- a/src/hark/networking/__init__.py
+++ b/src/hark/networking/__init__.py
@@ -1,0 +1,39 @@
+import ipaddress
+
+from hark.exceptions import NetworkFull
+
+
+DEFAULT_NETWORK = '192.168.168.0/24'
+
+
+class Network(object):
+    """
+    The Network class represents the hark network.
+
+    Hark gives all hosts a static IP in a private /24. The DEFAULT_NETWORK
+    value is chosen based the relative unlikelihood of it being in use in the
+    wild, at least in the networks of hark users.
+    """
+
+    def __init__(self, network=DEFAULT_NETWORK):
+        self.network = ipaddress.ip_network(network)
+
+    def hosts(self):
+        return [str(h) for h in self.network.hosts()]
+
+    def get_host_address(self):
+        return self.hosts()[0]
+
+    def get_free_address(self, exclude=[]):
+        """
+        Given a list of hosts to exclude - implicitly, addresses that have
+        already been assigned - return an available free IP address.
+        """
+        all_hosts = self.hosts()[1:]
+
+        available = [h for h in all_hosts if h not in exclude]
+
+        if len(available):
+            return available[0]
+        else:
+            raise NetworkFull(len(all_hosts))

--- a/src/hark/util/download.py
+++ b/src/hark/util/download.py
@@ -1,6 +1,4 @@
 import click
-from io import BufferedWriter
-from requests import Response
 
 
 def responseToFile(msg, response, f):

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -10,6 +10,7 @@ from hark.models import (
 )
 from hark.models.machine import Machine
 from hark.models.port_mapping import PortMapping
+from hark.models.network_interface import NetworkInterface
 
 
 class TestBaseModel(unittest.TestCase):
@@ -105,3 +106,14 @@ class TestPortMapping(unittest.TestCase):
         pm.validate()
         expect = 'bleh,tcp,127.0.0.1,11,,22'
         assert pm.format_virtualbox() == expect
+
+
+class TestNetworkInterface(unittest.TestCase):
+    def test_network_interface(self):
+        ni = NetworkInterface(
+            machine_id='1234',
+            kind='nat',
+            label='nic1',
+            addr=None)
+
+        ni.validate()

--- a/src/tests/test_networking.py
+++ b/src/tests/test_networking.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+
+import hark.exceptions
+import hark.networking
+
+
+class TestNetwork(TestCase):
+
+    def test_network(self):
+        nw = hark.networking.Network()
+
+        assert nw.get_host_address() == '192.168.168.1'
+
+        assert nw.get_free_address() == '192.168.168.2'
+
+        exclude = ['192.168.168.2']
+        assert nw.get_free_address(exclude=exclude) == '192.168.168.3'
+
+        exclude = ['192.168.168.2', '192.168.168.4']
+        assert nw.get_free_address(exclude=exclude) == '192.168.168.3'
+
+        exclude = nw.hosts()[1:]
+        self.assertRaises(
+            hark.exceptions.NetworkFull,
+            nw.get_free_address, exclude=exclude)


### PR DESCRIPTION
This is only relevant to virtualbox for now. Other drivers when added
will need a similar mechanism.

For this to work, there also needs to be a static IP created for the
host machine. This will probably break if we reuse a host-only interface
that was already there, so this branch may need a commit added whereby
hark can remember its exclusive host-only interface.

The Procedure API is refactored to be simpler.

The DAL is fixed to handle nulls. Lots of flake8 fixes.