### PR TITLE
[FIX] virtualbox: use a dedicated host-only interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ python:
   - "3.4"
   - "3.5"
 
-install: "(cd src && pip install -U pip && pip install -r requirements.txt && pip install -r requirements-dev.txt && pip install .)"
+install: "(cd src && pip install -U pip && pip install -U setuptools && pip install -r requirements.txt && pip install -r requirements-dev.txt && pip install .)"
 
 script: "cd src && python setup.py test"

--- a/src/hark/dal/schema.sql
+++ b/src/hark/dal/schema.sql
@@ -23,3 +23,10 @@ CREATE TABLE network_interface (
 
 	PRIMARY KEY (machine_id, kind)
 );
+
+CREATE TABLE config (
+	name  varchar(255),
+	value varchar(255),
+
+	PRIMARY KEY (name, value)
+);

--- a/src/hark/models/config.py
+++ b/src/hark/models/config.py
@@ -1,0 +1,13 @@
+from hark.models import SQLModel
+
+
+class Config(SQLModel):
+    """
+    A model for an arbitrary config value that is stored to the database.
+    """
+
+    table = 'config'
+    key = ['name', 'value']
+
+    fields = ['name', 'value']
+    required = ['name', 'value']

--- a/src/hark/procedure/__init__.py
+++ b/src/hark/procedure/__init__.py
@@ -66,7 +66,7 @@ class NewMachine(Procedure):
                 self.machine)
             raise Abort
 
-        self.driver().create(baseImagePath)
+        self.driver().create(baseImagePath, self.client.dal())
 
         self.createPortMapping()
 

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -8,6 +8,7 @@ from hark.models import (
     BaseModel,
     SQLModel,
 )
+from hark.models.config import Config
 from hark.models.machine import Machine
 from hark.models.port_mapping import PortMapping
 from hark.models.network_interface import NetworkInterface
@@ -117,3 +118,12 @@ class TestNetworkInterface(unittest.TestCase):
             addr=None)
 
         ni.validate()
+
+
+class TestConfig(unittest.TestCase):
+    def test_config(self):
+        cfg = Config(name='a', value='b')
+        cfg.validate()
+
+        cfg = Config(name='a')
+        self.assertRaises(ModelInvalidException, cfg.validate)


### PR DESCRIPTION
This adds a new config table which can persist global configuration like
the name of the host-only interface. With this change, hark never gets
the list of host-only interfaces from the system: it just creates one on
the first run for a context and records it in the DB through the DAL.
This means that the driver's create() method needs to be given a DAL
instance.

Resolves #8