### PR TITLE
[FEATURE] Support destroying VMs

### DIFF
--- a/src/hark/cli/hark.py
+++ b/src/hark/cli/hark.py
@@ -188,6 +188,32 @@ def stop(client, name):
 
 @vm.command()
 @click.pass_obj
+@click.option(
+    "--name", type=str,
+    prompt="Machine name", help="The name of the machine")
+def destroy(client, name):
+    "Destroy a machine"
+    import hark.driver
+    import hark.procedure
+
+    m = getMachine(client, name)
+
+    click.echo('Destroying machine: ' + name)
+
+    proc = hark.procedure.DestroyMachine(client, m)
+
+    try:
+        proc.run()
+    except hark.procedure.Abort:
+        raise click.Abort
+    finally:
+        printProcedureLines(proc)
+
+    click.secho('Done.', fg='green')
+
+
+@vm.command()
+@click.pass_obj
 def mappings(client):
     "Show all configured port mappings"
 

--- a/src/hark/client/__init__.py
+++ b/src/hark/client/__init__.py
@@ -21,7 +21,7 @@ class LocalClient(object):
         return self.dal().read(Machine)
 
     def createMachine(self, machine):
-        log.debug('Saving machine: %s', machine.json())
+        log.debug('dal: saving machine: %s', machine.json())
         self.dal().create(machine)
 
     def getMachine(self, name):
@@ -33,6 +33,25 @@ class LocalClient(object):
         if len(m) == 0:
             raise hark.exceptions.MachineNotFound
         return m[0]
+
+    def deleteMachine(self, machine):
+        from hark.models.network_interface import NetworkInterface
+        from hark.models.port_mapping import PortMapping
+        mid = machine['machine_id']
+
+        # delete the machine from the DB
+        log.debug('dal: deleting machine: %s', machine.json())
+        self.dal().delete(machine)
+
+        constraints = {'machine_id': mid}
+
+        # delete its network interfaces
+        log.debug('dal: deleting network interfaces for machine: %s' % mid)
+        self.dal().deleteWhere(NetworkInterface, constraints)
+
+        # delete its port ma[[ings
+        log.debug('dal: deleting port mappings for machine: %s' % mid)
+        self.dal().deleteWhere(PortMapping, constraints)
 
     def portMappings(self, name=None, machine_id=None):
         "Get all port mappings"
@@ -46,7 +65,7 @@ class LocalClient(object):
         return self.dal().read(PortMapping, constraints=constraints)
 
     def createPortMapping(self, mapping):
-        log.debug('Saving port mapping: %s', mapping)
+        log.debug('dal: saving port mapping: %s', mapping)
         self.dal().create(mapping)
 
     def networkInterfaces(self, machine=None, kind=None):
@@ -69,7 +88,7 @@ class LocalClient(object):
         return addr
 
     def createNetworkInterface(self, iface):
-        log.debug('Saving network interface: %s', iface)
+        log.debug('dal: saving network interface: %s', iface)
         self.dal().create(iface)
 
     def images(self):

--- a/src/hark/driver/base.py
+++ b/src/hark/driver/base.py
@@ -1,4 +1,7 @@
+import time
+
 import hark.guest
+import hark.log
 from hark.lib.command import which, Command
 
 
@@ -22,3 +25,26 @@ class BaseDriver(object):
         cmd = Command(cls.cmd, cls.versionArg)
         res = cmd.assertRun()
         return res.stdout.strip()
+
+    def assertStatus(self, msg, *valid_statuses):
+        """
+        Given a machine driver instance, throw hark.exceptions.InvalidStatus
+        unless the status of the machine is in the specified set.
+
+        msg is a message which will be used to format the exception.
+        """
+        s = self.status()
+
+        if s not in valid_statuses:
+            fmt = ', '.join(["'%s'" % str(st) for st in valid_statuses])
+            raise hark.exceptions.InvalidStatus(
+                "cannot destroy a machine unless it's stopped: "
+                "status is '%s' and needs to be one of (%s)" % (s, fmt))
+
+    def waitStatus(self, status, interval_ms=1000):
+        hark.log.info('Waiting for machine %s status to be %s' % (
+            self.machine['name'], status))
+        while True:
+            if self.status() == status:
+                return
+            time.sleep(interval_ms / 1000)

--- a/src/hark/driver/virtualbox/__init__.py
+++ b/src/hark/driver/virtualbox/__init__.py
@@ -111,6 +111,19 @@ class Driver(base.BaseDriver):
         cmd = self._controlvm('acpipowerbutton')
         self._run(cmd)
 
+    def destroy(self):
+        """
+        Destroy the machine: unregister it from virtualbox and remove its
+        backing volume.
+        """
+        # make sure we're powered off first
+        self.assertStatus(
+            "cannot destroy a machine unless it's stopped",
+            status.STOPPED, status.ABORTED)
+
+        cmd = ['unregistervm', self._name(), '--delete']
+        self._run(cmd)
+
     def setPortMappings(self, mappings):
         for pm in mappings:
             fpm = pm.format_virtualbox()

--- a/src/hark/exceptions/__init__.py
+++ b/src/hark/exceptions/__init__.py
@@ -77,6 +77,15 @@ class UnrecognisedMachineState(Exception):
     pass
 
 
+class InvalidStatus(Exception):
+    """
+    Exception used when the user tries to make an invalid status change to a
+    machine, e.g. destroying it while it's still running, or starting it, while
+    it's started, etc.
+    """
+    pass
+
+
 class BadHarkEnvironment(Exception):
     def __init__(self, *complaints):
         msg = "hark found %d issues with your environment; they were:\n%s" % (

--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -20,7 +20,7 @@ class TestGetFreePort(unittest.TestCase):
 
         # port should be 1003 and it should have been called four times
         assert p == 1003
-        mockGetSockName.asset_has_calls([call(), call(), call(), call()])
+        mockGetSockName.assert_has_calls([call(), call(), call(), call()])
 
 
 class TestCheckHarkEnv(unittest.TestCase):


### PR DESCRIPTION
This commit adds a new CLI command:

	hark vm destroy

This will:

* delete the VM from the driver
* delete the VM from the machine table

The driver needed support added to wait on a machine for a certain
state, so that the procedure to destroy can call stop() then wait for
the machine to be stopped before destroying it.

This commit needs to be amended to include deleting port mappings and
network interfaces.